### PR TITLE
Ignore status code 503

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ This is an Nagios/Icinga check plugin for
 [actuator framework](http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#production-ready).
 The check inspects the response from the health and metrics endpoints.
 
+Usage
+========
+Example:
+```
+./check_springboot_actuator.py -U "http://localhost:14041/testservice/v1/actuator" -N --th "metric=testservice_files_in_failure_value,ok=0,warning=1..20,critical=20.." -m testservice.files.in.failure
+```
+
 Features
 ========
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Usage
 ========
 Example:
 ```
-./check_springboot_actuator.py -U "http://localhost:14041/testservice/v1/actuator" -N --th "metric=testservice_files_in_failure_value,ok=0,warning=1..20,critical=20.." -m testservice.files.in.failure
+./check_springboot_actuator.py -U "http://localhost:14041/testservice/v1/actuator" -N --th "metric=testservice.files.in.failure.value,ok=0..0,warning=10..20,critical=20..inf" -m testservice.files.in.failure 
 ```
 
 Features

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 About check_springboot_actuator
 ===============================
 
-This is an Nagios/Icinga check plugin for
+This is a Nagios based check plugin for
 [Spring Boot](https://projects.spring.io/spring-boot/) applications using the
 [actuator framework](http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#production-ready).
 The check inspects the response from the health and metrics endpoints.
 
 Usage
 ========
-Example:
+Example usage health:
 ```
-./check_springboot_actuator.py -U "http://localhost:14041/testservice/v1/actuator" -N --th "metric=testservice.files.in.failure.value,ok=0..0,warning=10..20,critical=20..inf" -m testservice.files.in.failure 
+./check_springboot_actuator.py -U "http://localhost:14041/testservice/v1/actuator"
+```
+
+Example usage metrics:
+```
+./check_springboot_actuator.py -U "http://localhost:14041/testservice/v1/actuator" --th "metric=testservice.files.in.failure.value,ok=0..0,warning=1..20,critical=20..inf" -m testservice.files.in.failure
 ```
 
 Features
@@ -19,6 +24,8 @@ Features
 The check checks the status field from the health endpoint for
 
 - global status
+
+Pre-defined check detailed status for:
 - cassandra status
 - diskSpace status
 - db
@@ -32,8 +39,12 @@ The check checks the status field from the health endpoint for
 - solr status
 - vault
 
+Make sure you enable details for your endpoint: `management.endpoint.health.show-details: always` if you want detailed status.
+
 The check aggregates metrics for the counter.status data from the metrics
 endpoints.
+
+Check metrics based on specified thresholds. Note that when a metric is specified the health is no longer regarded.
 
 License
 =======

--- a/check_springboot_actuator.py
+++ b/check_springboot_actuator.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+#
+# Example usage:
+# ./check_springboot_actuator.py -U "http://localhost:14041/testservice/v1/actuator" -N --th "metric=testservice_files_in_failure_value,ok=0,warning=1..20,critical=20.." -m testservice.files.in.failure
 from __future__ import print_function
 
 import logging
@@ -23,7 +26,7 @@ helper.parser.add_option(
     dest='truststore')
 helper.parser.add_option(
     '-m', '--metrics',
-    help='comma separated list of metrics to display',
+    help='comma separated list of metrics to display, they can be combined with thresholds',
     dest='metrics')
 helper.parser.add_option(
     '-u', '--user-credentials',
@@ -160,5 +163,7 @@ else:
         handle_version_1()
     if version == 2:
         handle_version_2()
+
+helper.check_all_metrics()
 
 helper.exit()

--- a/check_springboot_actuator.py
+++ b/check_springboot_actuator.py
@@ -53,7 +53,7 @@ def request_data(url, **get_args):
     try:
         response = get(url, **get_args)
         # check response content type to determine which actuator api to be used
-        if response.ok:
+        if response.ok or response.status_code == 503:
             contenttype = response.headers['Content-Type']
             version = 1 if contenttype.startswith(contenttype_v1) else 2
             return response.json(), version, None

--- a/check_springboot_actuator.py
+++ b/check_springboot_actuator.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 #
 # Example usage:
-# ./check_springboot_actuator.py -U "http://localhost:14041/testservice/v1/actuator" -N --th "metric=testservice_files_in_failure_value,ok=0,warning=1..20,critical=20.." -m testservice.files.in.failure
+# ./check_springboot_actuator.py -U "http://localhost:14041/testservice/v1/actuator" -N --th "metric=testservice.files.in.failure.value,ok=0..0,warning=10..20,critical=20..inf" -m testservice.files.in.failure
+
 from __future__ import print_function
 
 import logging
@@ -87,7 +88,7 @@ def handle_version_1():
                 http_status_counter[status] = (
                     http_status_counter.get(status, 0) + json_data[key])
             else:
-                helper.add_metric(label=key.replace('.', '_'), value=json_data[key])
+                helper.add_metric(label=key, value=json_data[key])
 
         for status in http_status_counter:
             helper.add_metric(
@@ -116,7 +117,7 @@ def handle_version_2():
                 http_status_counter[status] = (
                         http_status_counter.get(status, 0) + measurement['value'])
             else:
-                helper.add_metric(label="%s_%s" % (key.replace('.', '_'), measurement['statistic'].lower()), value=measurement['value'])
+                helper.add_metric(label="%s.%s" % (key, measurement['statistic'].lower()), value=measurement['value'])
 
 
     for status in http_status_counter:


### PR DESCRIPTION
Spring actuator returns status code 503 on the health endpoint when it reports status DOWN. This should be seperated from other possible http exceptions.
It can be argued that the health endpoint should return the status code 200 since the prupose of the endpoint is to report the health in the json payload and not report the health using HTTP status code. But currently this is the default behaviour in spring actuator health.