### PR TITLE
Ignore http status code 503 on health endpoint

### DIFF
--- a/check_springboot_actuator.py
+++ b/check_springboot_actuator.py
@@ -53,7 +53,7 @@ def request_data(url, **get_args):
     try:
         response = get(url, **get_args)
         # check response content type to determine which actuator api to be used
-        if response.ok:
+        if response.ok or response.status_code == 503:
             contenttype = response.headers['Content-Type']
             version = 1 if contenttype.startswith(contenttype_v1) else 2
             return response.json(), version, None


### PR DESCRIPTION
Spring actuator returns status code 503 on the health endpoint when it reports status DOWN. This should be seperated from other possible http exceptions.
It can be argued that the health endpoint should return the status code 200 since the prupose of the endpoint is to report the health in the json payload and not report the health using HTTP status code.